### PR TITLE
Card wrapper

### DIFF
--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const AuthLayout = ({ children }: { children: React.ReactNode }) => {
+  return <div className="h-full flex items-center justify-center bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] from-sky-400 to-blue-800">
+    {children}
+    </div>;
+};
+
+export default AuthLayout;

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,10 @@
+import { LoginForm } from '@/components/auth/login-form'
+import React from 'react'
+
+const LoginPage = () => {
+  return (
+    <LoginForm />
+  )
+}
+
+export default LoginPage

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html,
+body,
+:root {
+  height: 100%;
+}
  
 @layer base {
   :root {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,46 @@
-import Image from 'next/image'
+import { Poppins } from "next/font/google"; //import { Poppins } from "@next/font/google"; //import { Poppins }
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { LoginButton } from "@/components/auth/login-button";
+
+const font = Poppins({
+  subsets: ["latin"],
+  weight: ["600"],
+});
 
 export default function Home() {
   return (
-    <div className='font-semibold'>Hi</div>
-  )
+    //centers the content
+    <main
+      className="
+          flex 
+          h-full 
+          flex-col 
+          items-center 
+          justify-center 
+          bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] from-sky-400 to-blue-800
+        "
+    >
+      <div className="space-y-6 text-center">
+        <h1
+          className={cn(
+            "text-6xl font-semibold tracking-tight text-white",
+            font.className
+          )}
+        >
+          🔒 Auth
+        </h1>
+        <p className="text-white text-lg">
+          A simple authentication servie using Next.js and Prisma.
+        </p>
+        <div>
+          <LoginButton>
+            <Button variant="secondary" size="lg">
+              Sign in
+            </Button>
+          </LoginButton>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/components/auth/back-button.tsx
+++ b/components/auth/back-button.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "../ui/button";
+
+interface BackButtonProps {
+  label: string;
+  href: string;
+}
+
+export const BackButton = ({ label, href }: BackButtonProps) => {
+  return (
+    <Button variant="link" className="font-normal w-full" size="sm" asChild>
+      <Link href={href}>{label}</Link>
+    </Button>
+  );
+};

--- a/components/auth/card-wrapper.tsx
+++ b/components/auth/card-wrapper.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Card, CardHeader, CardContent, CardFooter } from "../ui/card";
+import { BackButton } from "./back-button";
+import { Header } from "./header";
+import { Social } from "./social";
+
+interface CardWrapperProps {
+  children: React.ReactNode;
+  headerLabel: string;
+  backButtonLabel: string;
+  backButtonHref: string;
+  showSocial?: boolean;
+}
+
+export const CardWrapper = ({
+  children,
+  headerLabel,
+  backButtonLabel,
+  backButtonHref,
+  showSocial,
+}: CardWrapperProps) => {
+  return (
+    <Card className="w-[400px] shadow-md">
+      <CardHeader>
+        <Header label={headerLabel} />
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+      {showSocial && (
+        <CardFooter>
+          <Social />
+        </CardFooter>
+      )}
+      <CardFooter>
+        <BackButton label={backButtonLabel} href={backButtonHref} />
+      </CardFooter>
+    </Card>
+  );
+};

--- a/components/auth/header.tsx
+++ b/components/auth/header.tsx
@@ -1,0 +1,25 @@
+import { Poppins } from "next/font/google";
+
+import { cn } from "@/lib/utils";
+
+const font = Poppins({
+    subsets: ["latin"],
+    weight: ["600"],
+});
+
+interface HeaderProps {
+    label: string;
+}
+
+export const Header = ({ label }: HeaderProps) => {
+    return (
+        <div className="w-full flex flex-col gap-y-4 items-center justify-center">
+            <h1 className={cn("text-3xl font-semibold", font.className)}>
+                Auth
+            </h1>
+            <p className="text-muted-foreground text-small">
+                {label}
+            </p>
+        </div>
+    )
+}

--- a/components/auth/login-button.tsx
+++ b/components/auth/login-button.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useRouter } from "next/navigation";
+
+interface LoginButtonProps {
+    children: React.ReactNode;
+    mode?: "modal" | "redirect";
+    asChild?: boolean;
+}
+
+export const LoginButton = ({
+    children,
+    mode = "redirect",
+    asChild
+}: LoginButtonProps) => {
+    const router = useRouter()
+
+    const onClick = () => {
+        router.push("/auth/login")
+    }
+
+    if(mode === "modal") {
+        return (
+            <button onClick={onClick} className="curson-pointer">
+                Hi
+            </button>
+        )
+    }
+
+    return (
+        <span onClick={onClick} className="curson-pointer">
+            {children}
+        </span>
+    )
+}

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { CardWrapper } from "./card-wrapper";
+
+export const LoginForm = () => {
+  return (
+    <CardWrapper
+      headerLabel="Welcome back"
+      backButtonLabel="Don't have an account?"
+      backButtonHref="/auth/register"
+      showSocial
+    >
+      login-form
+    </CardWrapper>
+  );
+};

--- a/components/auth/social.tsx
+++ b/components/auth/social.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { FcGoogle } from "react-icons/fc";
+import { FaGithub } from "react-icons/fa";
+import { Button } from "../ui/button";
+
+export const Social = () => {
+  return <div className="flex items-center w-full gap-x-2">
+    <Button size="lg" className="w-full" variant="outline" onClick={(() => {})}>
+        <FcGoogle className="w-5 h-5" />
+    </Button>
+
+    <Button size="lg" className="w-full" variant="outline" onClick={(() => {})}>
+        <FaGithub className="w-5 h-5" />
+    </Button>
+  </div>;
+};

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "next": "14.0.4",
@@ -423,12 +424,47 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.0.tgz",
       "integrity": "sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -464,13 +500,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.47",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
       "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -490,7 +526,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.18.1",
@@ -1203,7 +1239,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "14.0.4",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.0.1",
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -3633,6 +3634,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "next": "14.0.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "14.0.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-icons": "^5.0.1",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
To render authentication content, such as a login page and a register page, a card wrapper component has been created. First, an "auth" folder was created in the root app folder, indicating that pages implemented in this folder will be served on the `/auth` route. Therefore, the `page.tsx` is the file that will be displayed on that route, and the content of `layout.tsx` will be applied to the page in that folder and to the nested routes.

In `layout.tsx`, a basic layout has been created to style children in the center and applied a gradient. Note: to center the content, the style `h-full flex items-center justify-center` has been applied. This is a reminder note for future reference.

The `page.tsx` in the "auth" folder renders the `LoginForm` component.

### Components:

1. **login-form.tsx:**
   - Contains the `CardWrapper` component with some props passed to it.
   - Aims to grasp the idea of how to create a component API, determining which logic should be turned into a component and how that component should be designed.

2. **card-wrapper.tsx:**
   - The `CardWrapper` component accepts some props, as seen in the file.
   - Internally uses Shadcn's `Card` component and other card-related elements like `CardHeader`, `CardContent`, etc.

3. **header.tsx:**
   - The `Header` component renders the header for the login form, which is hard-coded to "Auth."
   - It also renders a label accepted as a prop and is used in the `Card` component nested in `CardHeader`.

4. **social.tsx:**
   - This component renders buttons for OAuth.
   - Rendered conditionally in the `Card` component based on the `showSocial` prop, which is actually passed to the `CardWrapper` component.
   - Rendered between `CardFooter` elements.

5. **back-button.tsx:**
   - The `BackButton` component renders a label with a link, both of which are passed as props.
